### PR TITLE
Add TODO API

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,54 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Deploy to AWS
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-1'
+        run: npm run deploy

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -1,0 +1,5 @@
+import * as cdk from 'aws-cdk-lib';
+import { TodoApiStack } from './lib/todo-api-stack';
+
+const app = new cdk.App();
+new TodoApiStack(app, 'TodoApiStack');

--- a/cdk/lib/todo-api-stack.ts
+++ b/cdk/lib/todo-api-stack.ts
@@ -1,0 +1,67 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+
+export class TodoApiStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // DynamoDB table
+    const table = new dynamodb.Table(this, 'TodosTable', {
+      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
+    });
+
+    // Lambda functions
+    const getTodosLambda = new lambda.Function(this, 'GetTodosFunction', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      code: lambda.Code.fromAsset('src/handlers'),
+      handler: 'getTodos.getTodos',
+      environment: {
+        DYNAMODB_TABLE: table.tableName,
+      },
+    });
+
+    const postTodoLambda = new lambda.Function(this, 'PostTodoFunction', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      code: lambda.Code.fromAsset('src/handlers'),
+      handler: 'postTodo.postTodo',
+      environment: {
+        DYNAMODB_TABLE: table.tableName,
+      },
+    });
+
+    const deleteTodoLambda = new lambda.Function(this, 'DeleteTodoFunction', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      code: lambda.Code.fromAsset('src/handlers'),
+      handler: 'deleteTodo.deleteTodo',
+      environment: {
+        DYNAMODB_TABLE: table.tableName,
+      },
+    });
+
+    // Grant the Lambda functions read/write permissions to the DynamoDB table
+    table.grantReadWriteData(getTodosLambda);
+    table.grantReadWriteData(postTodoLambda);
+    table.grantReadWriteData(deleteTodoLambda);
+
+    // API Gateway
+    const api = new apigateway.RestApi(this, 'todosApi', {
+      restApiName: 'Todos Service',
+      description: 'This service serves todos.',
+    });
+
+    const todos = api.root.addResource('todos');
+    const singleTodo = todos.addResource('{id}');
+
+    const getTodosIntegration = new apigateway.LambdaIntegration(getTodosLambda);
+    const postTodoIntegration = new apigateway.LambdaIntegration(postTodoLambda);
+    const deleteTodoIntegration = new apigateway.LambdaIntegration(deleteTodoLambda);
+
+    todos.addMethod('GET', getTodosIntegration);
+    todos.addMethod('POST', postTodoIntegration);
+    singleTodo.addMethod('DELETE', deleteTodoIntegration);
+  }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: TODO API
+  description: API for managing TODO items
+  version: 1.0.0
+paths:
+  /todos:
+    get:
+      summary: Get TODO list
+      operationId: getTodos
+      responses:
+        '200':
+          description: A list of TODO items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Todo'
+    post:
+      summary: Create a new TODO item
+      operationId: postTodo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Todo'
+      responses:
+        '201':
+          description: The created TODO item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Todo'
+  /todos/{id}:
+    delete:
+      summary: Delete a TODO item
+      operationId: deleteTodo
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: TODO item deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+components:
+  schemas:
+    Todo:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum:
+            - 対応済み
+            - 未対応

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "todo-api",
+  "version": "1.0.0",
+  "description": "TODO API for managing TODO items",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "deploy": "cdk deploy"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.814.0",
+    "zod": "^3.11.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.2",
+    "vitest": "1.6.0",
+    "aws-cdk": "^1.122.0"
+  },
+  "engines": {
+    "node": ">=20.x"
+  }
+}

--- a/src/handlers/deleteTodo.ts
+++ b/src/handlers/deleteTodo.ts
@@ -1,0 +1,29 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { DynamoDB } from 'aws-sdk';
+
+const dynamoDb = new DynamoDB.DocumentClient();
+
+export const deleteTodo: APIGatewayProxyHandler = async (event, _context) => {
+  try {
+    const { id } = event.pathParameters!;
+
+    const params = {
+      TableName: process.env.DYNAMODB_TABLE!,
+      Key: {
+        id,
+      },
+    };
+
+    await dynamoDb.delete(params).promise();
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: 'Todo deleted successfully' }),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Could not delete todo' }),
+    };
+  }
+};

--- a/src/handlers/getTodos.ts
+++ b/src/handlers/getTodos.ts
@@ -1,0 +1,24 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { DynamoDB } from 'aws-sdk';
+
+const dynamoDb = new DynamoDB.DocumentClient();
+
+export const getTodos: APIGatewayProxyHandler = async (event, _context) => {
+  try {
+    const params = {
+      TableName: process.env.DYNAMODB_TABLE!,
+    };
+
+    const result = await dynamoDb.scan(params).promise();
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(result.Items),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Could not fetch todos' }),
+    };
+  }
+};

--- a/src/handlers/postTodo.ts
+++ b/src/handlers/postTodo.ts
@@ -1,0 +1,39 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { DynamoDB } from 'aws-sdk';
+import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+
+const dynamoDb = new DynamoDB.DocumentClient();
+
+const todoSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  status: z.enum(['対応済み', '未対応']),
+});
+
+export const postTodo: APIGatewayProxyHandler = async (event, _context) => {
+  try {
+    const body = JSON.parse(event.body!);
+    const parsedBody = todoSchema.parse(body);
+
+    const params = {
+      TableName: process.env.DYNAMODB_TABLE!,
+      Item: {
+        id: uuidv4(),
+        ...parsedBody,
+      },
+    };
+
+    await dynamoDb.put(params).promise();
+
+    return {
+      statusCode: 201,
+      body: JSON.stringify(params.Item),
+    };
+  } catch (error) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Could not create todo' }),
+    };
+  }
+};

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -1,0 +1,11 @@
+export interface Todo {
+  id: string;
+  title: string;
+  description: string;
+  status: TodoStatus;
+}
+
+export enum TodoStatus {
+  Done = '対応済み',
+  Pending = '未対応',
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const todoSchema = z.object({
+  title: z.string().nonempty('Title is required'),
+  description: z.string().nonempty('Description is required'),
+  status: z.enum(['対応済み', '未対応']),
+});
+
+export const validateTodo = (todo: unknown) => {
+  return todoSchema.safeParse(todo);
+};

--- a/tests/deleteTodo.test.ts
+++ b/tests/deleteTodo.test.ts
@@ -1,0 +1,44 @@
+import { deleteTodo } from '../src/handlers/deleteTodo';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { DynamoDB } from 'aws-sdk';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('aws-sdk', () => {
+  const mDocumentClient = {
+    delete: vi.fn().mockReturnThis(),
+    promise: vi.fn(),
+  };
+  return { DynamoDB: { DocumentClient: vi.fn(() => mDocumentClient) } };
+});
+
+describe('deleteTodo', () => {
+  it('should delete a todo item', async () => {
+    const mDocumentClient = new DynamoDB.DocumentClient();
+    mDocumentClient.delete().promise.mockResolvedValueOnce({});
+
+    const event: APIGatewayProxyEvent = {
+      pathParameters: { id: '1' },
+    } as any;
+    const context: Context = {} as any;
+
+    const result = await deleteTodo(event, context);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toBe(JSON.stringify({ message: 'Todo deleted successfully' }));
+  });
+
+  it('should return an error if DynamoDB delete fails', async () => {
+    const mDocumentClient = new DynamoDB.DocumentClient();
+    mDocumentClient.delete().promise.mockRejectedValueOnce(new Error('DynamoDB delete failed'));
+
+    const event: APIGatewayProxyEvent = {
+      pathParameters: { id: '1' },
+    } as any;
+    const context: Context = {} as any;
+
+    const result = await deleteTodo(event, context);
+
+    expect(result.statusCode).toBe(500);
+    expect(result.body).toBe(JSON.stringify({ error: 'Could not delete todo' }));
+  });
+});

--- a/tests/getTodos.test.ts
+++ b/tests/getTodos.test.ts
@@ -1,0 +1,44 @@
+import { getTodos } from '../src/handlers/getTodos';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { DynamoDB } from 'aws-sdk';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('aws-sdk', () => {
+  const mDocumentClient = {
+    scan: vi.fn().mockReturnThis(),
+    promise: vi.fn(),
+  };
+  return { DynamoDB: { DocumentClient: vi.fn(() => mDocumentClient) } };
+});
+
+describe('getTodos', () => {
+  it('should return a list of todos', async () => {
+    const mDocumentClient = new DynamoDB.DocumentClient();
+    const todos = [
+      { id: '1', title: 'Test Todo 1', description: 'Description 1', status: '未対応' },
+      { id: '2', title: 'Test Todo 2', description: 'Description 2', status: '対応済み' },
+    ];
+    mDocumentClient.scan().promise.mockResolvedValueOnce({ Items: todos });
+
+    const event: APIGatewayProxyEvent = {} as any;
+    const context: Context = {} as any;
+
+    const result = await getTodos(event, context);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toBe(JSON.stringify(todos));
+  });
+
+  it('should return an error if DynamoDB scan fails', async () => {
+    const mDocumentClient = new DynamoDB.DocumentClient();
+    mDocumentClient.scan().promise.mockRejectedValueOnce(new Error('DynamoDB scan failed'));
+
+    const event: APIGatewayProxyEvent = {} as any;
+    const context: Context = {} as any;
+
+    const result = await getTodos(event, context);
+
+    expect(result.statusCode).toBe(500);
+    expect(result.body).toBe(JSON.stringify({ error: 'Could not fetch todos' }));
+  });
+});

--- a/tests/postTodo.test.ts
+++ b/tests/postTodo.test.ts
@@ -1,0 +1,65 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { postTodo } from '../src/handlers/postTodo';
+import { DynamoDB } from 'aws-sdk';
+import { TodoStatus } from '../src/models/todo';
+
+jest.mock('aws-sdk', () => {
+  const mDocumentClient = {
+    put: jest.fn().mockReturnThis(),
+    promise: jest.fn(),
+  };
+  return {
+    DynamoDB: {
+      DocumentClient: jest.fn(() => mDocumentClient),
+    },
+  };
+});
+
+describe('postTodo', () => {
+  let event: APIGatewayProxyEvent;
+  let context: Context;
+  let callback: any;
+  let dynamoDb: DynamoDB.DocumentClient;
+
+  beforeEach(() => {
+    event = {
+      body: JSON.stringify({
+        title: 'Test TODO',
+        description: 'This is a test TODO',
+        status: TodoStatus.Pending,
+      }),
+    } as any;
+    context = {} as any;
+    callback = jest.fn();
+    dynamoDb = new DynamoDB.DocumentClient();
+  });
+
+  it('should create a new TODO item', async () => {
+    const putSpy = jest.spyOn(dynamoDb, 'put').mockReturnValue({
+      promise: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    const result = await postTodo(event, context, callback);
+
+    expect(result.statusCode).toBe(201);
+    const body = JSON.parse(result.body);
+    expect(body.title).toBe('Test TODO');
+    expect(body.description).toBe('This is a test TODO');
+    expect(body.status).toBe(TodoStatus.Pending);
+    expect(putSpy).toHaveBeenCalled();
+  });
+
+  it('should return 400 if validation fails', async () => {
+    event.body = JSON.stringify({
+      title: '',
+      description: 'This is a test TODO',
+      status: TodoStatus.Pending,
+    });
+
+    const result = await postTodo(event, context, callback);
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toBe('Could not create todo');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["./tsc-cache"],
+    globals: true,
+    env: {},
+  },
+  plugins: [tsconfigPaths()],
+});


### PR DESCRIPTION
Related to #1

Implement the TODO API with GET, POST, and DELETE endpoints.

* **API Endpoints:**
  - Add `src/handlers/getTodos.ts` to implement the GET /todos endpoint.
  - Add `src/handlers/postTodo.ts` to implement the POST /todos endpoint.
  - Add `src/handlers/deleteTodo.ts` to implement the DELETE /todos/{id} endpoint.

* **Infrastructure:**
  - Add `cdk/app.ts` to set up the AWS CDK application.
  - Add `cdk/lib/todo-api-stack.ts` to define the CDK stack for the TODO API, including API Gateway, Lambda functions, and DynamoDB table.

* **Configuration:**
  - Add `package.json` to define project dependencies and scripts.
  - Add `tsconfig.json` to configure TypeScript for the project.

* **Models and Validation:**
  - Add `src/models/todo.ts` to define the TODO item structure and status enum.
  - Add `src/utils/validation.ts` to implement validation functions using `zod`.

* **Testing:**
  - Add `tests/getTodos.test.ts` to implement unit tests for the GET /todos endpoint.
  - Add `tests/postTodo.test.ts` to implement unit tests for the POST /todos endpoint.
  - Add `tests/deleteTodo.test.ts` to implement unit tests for the DELETE /todos/{id} endpoint.

* **CI/CD:**
  - Add `.github/workflows/ci-cd.yml` to set up GitHub Actions workflow for CI/CD.

* **Documentation:**
  - Add `openapi.yaml` to define the API endpoints' specifications using OpenAPI 3.0.3.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joe-king-sh/todo-api-with-github-copilot-workspace-from-scrach/issues/1?shareId=7a9e8bb4-0d77-4932-a0e5-b7c45f2fb0fc).