### PR TITLE
Setup npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Node.js dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment variable files
+.env

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.2",
+  "language": "ja",
+  "ignorePaths": [
+    "node_modules",
+    "dist",
+    "*.env"
+  ]
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "infra",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "5.5.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "todo-api-with-github-copilot-workspace-from-scrach",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "infra",
+    "server"
+  ],
+  "engines": {
+    "node": "20.11.1"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "5.5.2"
+  }
+}


### PR DESCRIPTION
Related to #4

Set up npm packages and workspaces for the TODO API project.

* **Root package.json**: Initialize npm package, add workspaces configuration to include `infra` and `server` directories, and set Node.js version to `20.11.1`.
* **Infra package.json**: Initialize npm package, set package name to `infra`, and set TypeScript version to `5.5.2`.
* **Server package.json**: Initialize npm package, set package name to `server`, and set TypeScript version to `5.5.2`.
* **.gitignore**: Add `node_modules/`, `dist/`, and `.env` to ignore Node.js dependencies, build output, and environment variable files.
* **cspell.json**: Initialize cspell configuration, add `node_modules`, `dist`, and `*.env` to ignorePaths.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joe-king-sh/todo-api-with-github-copilot-workspace-from-scrach/issues/4?shareId=e2e49f53-0acf-44b1-9539-1463eda875bd).