### PR TITLE
Add OpenAPI specification for TODO API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,93 @@
+openapi: 3.0.3
+info:
+  title: TODO API
+  description: API for managing TODO items
+  version: 1.0.0
+paths:
+  /todos:
+    get:
+      summary: Get list of TODO items
+      responses:
+        '200':
+          description: A list of TODO items
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Todo'
+    post:
+      summary: Create a new TODO item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Todo'
+      responses:
+        '201':
+          description: TODO item created
+  /todos/{id}:
+    get:
+      summary: Get a TODO item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A TODO item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Todo'
+    put:
+      summary: Update a TODO item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Todo'
+      responses:
+        '200':
+          description: TODO item updated
+    delete:
+      summary: Delete a TODO item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: TODO item deleted
+components:
+  schemas:
+    Todo:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        content:
+          type: string
+        status:
+          $ref: '#/components/schemas/Status'
+        createdAt:
+          type: string
+          format: date-time
+    Status:
+      type: string
+      enum:
+        - DONE
+        - IN_PROGRESS
+        - TODO


### PR DESCRIPTION
Related to #7

Add `openapi.yaml` file to the project root to define the TODO API endpoints and schema.

* Define the OpenAPI version as 3.0.3.
* Add the `info` section with title, description, and version.
* Add the `paths` section with endpoints for TODO registration, list retrieval, update, and deletion.
* Define the TODO item schema with `id`, `title`, `content`, `status`, and `createdAt`.
* Add the `components` section with schemas for TODO item and status.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joe-king-sh/todo-api-with-github-copilot-workspace-from-scrach/issues/7?shareId=49700f7f-a930-48cd-b8f1-5d6913efdc3d).